### PR TITLE
feat: Set `prettier` as default formatter for HTML in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
   },
   "[pug]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,49 +1,115 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <meta name="og:type" content="website" />
+    <meta name="og:locale" content="en_US" />
+    <meta name="og:site" content="Holdex" />
+    <meta name="og:site_name" content="Holdex" />
+    <meta name="twitter:site" content="@HoldexIo" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="fb:app_id" content="2433638133411814" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+    <link
+      id="favicon-57"
+      rel="apple-touch-icon"
+      sizes="57x57"
+      href="%sveltekit.assets%/favicon/apple-icon-57x57.png"
+    />
+    <link
+      id="favicon-60"
+      rel="apple-touch-icon"
+      sizes="60x60"
+      href="%sveltekit.assets%/favicon/apple-icon-60x60.png"
+    />
+    <link
+      id="favicon-72"
+      rel="apple-touch-icon"
+      sizes="72x72"
+      href="%sveltekit.assets%/favicon/apple-icon-72x72.png"
+    />
+    <link
+      id="favicon-76"
+      rel="apple-touch-icon"
+      sizes="76x76"
+      href="%sveltekit.assets%/favicon/apple-icon-76x76.png"
+    />
+    <link
+      id="favicon-114"
+      rel="apple-touch-icon"
+      sizes="114x114"
+      href="%sveltekit.assets%/favicon/apple-icon-114x114.png"
+    />
+    <link
+      id="favicon-120"
+      rel="apple-touch-icon"
+      sizes="120x120"
+      href="%sveltekit.assets%/favicon/apple-icon-120x120.png"
+    />
+    <link
+      id="favicon-144"
+      rel="apple-touch-icon"
+      sizes="144x144"
+      href="%sveltekit.assets%/favicon/apple-icon-144x144.png"
+    />
+    <link
+      id="favicon-152"
+      rel="apple-touch-icon"
+      sizes="152x152"
+      href="%sveltekit.assets%/favicon/apple-icon-152x152.png"
+    />
+    <link
+      id="favicon-180"
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="%sveltekit.assets%/favicon/apple-icon-180x180.png"
+    />
+    <link
+      id="favicon-192"
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="%sveltekit.assets%/favicon/android-icon-192x192.png"
+    />
+    <link
+      id="favicon-92"
+      rel="icon"
+      type="image/png"
+      sizes="96x96"
+      href="%sveltekit.assets%/favicon/favicon-96x96.png"
+    />
+    <link
+      id="favicon-32"
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="%sveltekit.assets%/favicon/favicon-32x32.png"
+    />
+    <link
+      id="favicon-16"
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="%sveltekit.assets%/favicon/favicon-16x16.png"
+    />
+    <meta name="msapplication-TileColor" content="#ffffff" />
+    <meta name="msapplication-TileImage" content="%sveltekit.assets%/favicon/ms-icon-144x144.png" />
+    <link rel="manifest" href="%sveltekit.assets%/favicon/site.webmanifest" />
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta name="og:type" content="website" />
-  <meta name="og:locale" content="en_US" />
-  <meta name="og:site" content="Holdex" />
-  <meta name="og:site_name" content="Holdex" />
-  <meta name="twitter:site" content="@HoldexIo" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta property="fb:app_id" content="2433638133411814" />
-  <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
-  <link id="favicon-57" rel="apple-touch-icon" sizes="57x57" href="%sveltekit.assets%/favicon/apple-icon-57x57.png" />
-  <link id="favicon-60" rel="apple-touch-icon" sizes="60x60" href="%sveltekit.assets%/favicon/apple-icon-60x60.png" />
-  <link id="favicon-72" rel="apple-touch-icon" sizes="72x72" href="%sveltekit.assets%/favicon/apple-icon-72x72.png" />
-  <link id="favicon-76" rel="apple-touch-icon" sizes="76x76" href="%sveltekit.assets%/favicon/apple-icon-76x76.png" />
-  <link id="favicon-114" rel="apple-touch-icon" sizes="114x114"
-    href="%sveltekit.assets%/favicon/apple-icon-114x114.png" />
-  <link id="favicon-120" rel="apple-touch-icon" sizes="120x120"
-    href="%sveltekit.assets%/favicon/apple-icon-120x120.png" />
-  <link id="favicon-144" rel="apple-touch-icon" sizes="144x144"
-    href="%sveltekit.assets%/favicon/apple-icon-144x144.png" />
-  <link id="favicon-152" rel="apple-touch-icon" sizes="152x152"
-    href="%sveltekit.assets%/favicon/apple-icon-152x152.png" />
-  <link id="favicon-180" rel="apple-touch-icon" sizes="180x180"
-    href="%sveltekit.assets%/favicon/apple-icon-180x180.png" />
-  <link id="favicon-192" rel="icon" type="image/png" sizes="192x192"
-    href="%sveltekit.assets%/favicon/android-icon-192x192.png" />
-  <link id="favicon-92" rel="icon" type="image/png" sizes="96x96" href="%sveltekit.assets%/favicon/favicon-96x96.png" />
-  <link id="favicon-32" rel="icon" type="image/png" sizes="32x32" href="%sveltekit.assets%/favicon/favicon-32x32.png" />
-  <link id="favicon-16" rel="icon" type="image/png" sizes="16x16" href="%sveltekit.assets%/favicon/favicon-16x16.png" />
-  <meta name="msapplication-TileColor" content="#ffffff" />
-  <meta name="msapplication-TileImage" content="%sveltekit.assets%/favicon/ms-icon-144x144.png" />
-  <link rel="manifest" href="%sveltekit.assets%/favicon/site.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+    %sveltekit.head%
+  </head>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
-    rel="stylesheet" />
-  %sveltekit.head%
-</head>
-
-<body data-sveltekit-preload-data="hover">
-  <div style="display: contents">%sveltekit.body%</div>
-</body>
-
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
 </html>


### PR DESCRIPTION
A quick-fix to fix slight ish with indentation of the `head` element in `app.html`