### PR TITLE
fix: removed category name from title on article pageas in issue #370

### DIFF
--- a/src/routes/(pages)/c/[slug]/[messageSlug]/+page.svelte
+++ b/src/routes/(pages)/c/[slug]/[messageSlug]/+page.svelte
@@ -67,9 +67,7 @@
 </script>
 
 <MetaTags
-  title={message.communitySlug === 'holdex'
-    ? message.title
-    : `${community.name} - ${message.title}`}
+  title={message.title}
   description={message.subtitle ? message.subtitle : ''}
   pageType="article"
   path={routes.message(message.communitySlug, message.messageSlug)}


### PR DESCRIPTION
[Description]:

Removed category name from articles page title as it is defined in issue #370 