### PR TITLE
fix: fix spacing mistake in portfolio card

### DIFF
--- a/src/lib/components/Portfolio/template.pug
+++ b/src/lib/components/Portfolio/template.pug
@@ -64,7 +64,7 @@ mixin metric(type, value=null)
         h2(
           class="relative text-h2-l xs:text-h2-s font-satoshi inline-block underline underline-offset-4 bg-accent1-default/15 text-accent1-default transition-colors hover:bg-accent1-default/25 focus:bg-accent1-default/25"
         ) {title}
-    TextParagraph {subtitle}
+      TextParagraph {subtitle}
     +if('isFeatured == true')
       TextParagraph {description}
       .portfolio-metrics(class="w-full flex flex-wrap gap-8 smDown:flex-col smDown:gap-6")


### PR DESCRIPTION
resolves holdex/marketing#15

There was a pixel perfect issue in the portfolio page caused by a mistake in indentation. 

