### PR TITLE
fix: adjust padding to gradient background & add scrollable animation in mobile view

### DIFF
--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -63,7 +63,7 @@ mixin social
     .header-wrapper(class="w-full whitespace-nowrap lg-up:justify-center ")
       div(class="border-b border-solid border-l4 bg-l1 py-0 ")
         div(
-          class="px-4 flex items-center justify-between mx-auto gap-4 sm-up:w-full xl-up:max-w-screen-xl-up h-[64px]"
+          class="pl-4 flex items-center justify-between gap-2 mx-auto sm-up:w-full xl-up:max-w-screen-xl-up h-[64px]"
         )
           .logo-wrapper(class="relative w-8 h-8 ")
             a(class="relative flex  h-6.5 tbDown:w-30 tbDown:h-8" href="{routes.index}"): SVGIcon(
@@ -71,10 +71,10 @@ mixin social
               class="w-8 h-8 "
             )
 
-          div(id="secondary-navbar" class!="relative z-[11] bg-l1 overflow-x-scroll scrollbar-hide w-full flex")
+          div(id="secondary-navbar" class!="relative z-[11] bg-l1 overflow-x-scroll scrollbar-hide w-full flex pl-2 pr-4 [mask-image:_linear-gradient(to_right,transparent_0,_black_24px,_black_calc(100%-24px),transparent_100%)]")
             div(
               id="secondary-navbar-section h-full"
-              class!="px-4 flex gap-x-8 items-center justify-between mx-auto gap-4 w-max from-l1 to-transparent sm-up:w-full xl-up:max-w-screen-xl-up py-2 sm-up:py-4"
+              class!="px-4 flex gap-x-8 items-center justify-between mx-auto gap-4 w-max from-l1 to-transparent sm-up:w-full xl-up:max-w-screen-xl-up py-2 sm-up:py-4 animate-navigation-left-right md-up:animate-none"
             )
               +main-nav(class="gap-6")
               +social

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -352,12 +352,17 @@ module.exports = {
       animation: {
         'infinite-scroll-companies': 'infinite-scroll 15s linear infinite',
         'infinite-scroll': 'infinite-scroll 10s linear infinite',
+        'navigation-left-right': 'navigation-left-right 0.6s ease-out forwards',
       },
       keyframes: {
         'infinite-scroll': {
           from: { transform: 'translateX(0)' },
           to: { transform: 'translateX(calc(-100% - 24px))' },
         },
+        'navigation-left-right': {
+          '0%, 100%': { transform: 'translateX(0)' },
+          '33%, 66%': { transform: 'translateX(-100px)' }
+        }
       },
       backgroundImage: {
         'card-1-dark': "url('/cardBg/card-1-bg-dark.png')",


### PR DESCRIPTION
resolves [holdex/marketing#71](https://github.com/holdex/marketing/issues/71)

Note: I change padding in mobile view navigation into smooth gradient background to avoid menus cut off & add small interaction/animation in row of menus so user know it's scrollable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling and layout for the header and secondary navigation components.
	- Introduced a new animation for smoother transitions in navigation elements.
  
- **Improvements**
	- Adjusted padding and spacing for better visual alignment and responsiveness across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->