### PR TITLE
docs(ui): add team photos in About Page

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,3 +4,6 @@
 ## Guides
 
 - [/guides](https://www.figma.com/file/39MGGVIGQ1bL3FgVzuXEdC/Holdex?type=design&node-id=7017%3A51989&mode=design&t=t0tAdHirdZn2fo9l-1)
+
+## About
+- [/about](https://www.figma.com/design/i1YVZpDMylRZx3STm1QoGk/Holdex-Team-Photos?node-id=2-22056&t=dZeU16D19Meb3ue7-1)


### PR DESCRIPTION
### Summary

Created Team Photos section design for About Page

- 3 versions
- Dark/Light mode

Figma link: https://www.figma.com/design/i1YVZpDMylRZx3STm1QoGk/Holdex-Team-Photos?node-id=2-22056&t=dZeU16D19Meb3ue7-1

Goal: https://github.com/holdex/marketing/issues/73

ETA: 10h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "About" section in the DESIGN.md file, enhancing the document's structure.
	- Added a link to a design file related to team photos for easy access. 

- **Improvements**
	- Reformatted existing links to ensure proper line endings for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

resolves: https://github.com/holdex/marketing/issues/73