### PR TITLE
feat(ui): view thirdweb-svelte in portfolio list

### DIFF
--- a/src/lib/components/Portfolio/index.svelte
+++ b/src/lib/components/Portfolio/index.svelte
@@ -118,6 +118,12 @@
     'defi',
     'exchange',
     'python',
+    'poap',
+    'nft',
+    'decentraland',
+    'did',
+    'kyc',
+    'collateralized',
   ];
 </script>
 

--- a/src/lib/components/Portfolio/index.svelte
+++ b/src/lib/components/Portfolio/index.svelte
@@ -117,6 +117,7 @@
     'gaming',
     'defi',
     'exchange',
+    'python',
   ];
 </script>
 

--- a/src/lib/components/Portfolio/index.svelte
+++ b/src/lib/components/Portfolio/index.svelte
@@ -101,6 +101,11 @@
     'nostr',
     'social-dapp',
     'options-trading',
+    'voip',
+    'streaming',
+    'lending',
+    'index',
+    'nodejs',
   ];
 </script>
 

--- a/src/lib/components/Portfolio/index.svelte
+++ b/src/lib/components/Portfolio/index.svelte
@@ -109,6 +109,14 @@
     'wallet',
     'open-source',
     'typescript',
+    'dapp',
+    'go',
+    'ai',
+    'design',
+    'oracle',
+    'gaming',
+    'defi',
+    'exchange',
   ];
 </script>
 

--- a/src/lib/components/Portfolio/index.svelte
+++ b/src/lib/components/Portfolio/index.svelte
@@ -106,6 +106,9 @@
     'lending',
     'index',
     'nodejs',
+    'wallet',
+    'open-source',
+    'typescript',
   ];
 </script>
 

--- a/src/routes/(pages)/portfolio/template.pug
+++ b/src/routes/(pages)/portfolio/template.pug
@@ -124,10 +124,18 @@ include ../c/mixins
         )
         PortfolioItem(
           isFeatured=false
+          slug="https://thirdweb-svelte.vercel.app/"
+          isExternal
+          title="Thirdweb Svelte"
+          subtitle="Svelte SDK for seamless thirdweb integration"
+          hashtags=["software-development"]
+        )
+        PortfolioItem(
+          isFeatured=false
           slug="c/companies/finoverse"
           title="Finoverse"
           subtitle="A global network of FinTech and Web3 professionals and investors."
-          hashtags=["streaming", "voip", "design", "software-development", "react", "go"]
+          hashtags=["streaming", "voip", "design", "react", "go"]
         )
         PortfolioItem(
           isFeatured=false

--- a/src/routes/(pages)/portfolio/template.pug
+++ b/src/routes/(pages)/portfolio/template.pug
@@ -71,7 +71,7 @@ include ../c/mixins
           isExternal
           title="USDX"
           subtitle="1:1 fully backed and licensed USD stablecoin with 24/7 availability."
-          reservesInUsd=18366090.75
+          reservesInUsd=23193005.47
           description="A stablecoin created to bridge RWA and DeFi, USDX is backed by cash and cash equivalents under a fully licensed digital asset custodian."
           hashtags=["defi", "stablecoin", "multi-chain"]
         )

--- a/src/routes/(pages)/portfolio/template.pug
+++ b/src/routes/(pages)/portfolio/template.pug
@@ -127,8 +127,8 @@ include ../c/mixins
           slug="https://thirdweb-svelte.vercel.app/"
           isExternal
           title="Thirdweb Svelte"
-          subtitle="Svelte SDK for seamless thirdweb integration"
-          hashtags=["software-development"]
+          subtitle="Open-source Svelte SDK for thirdweb, developed by Holdex. It includes out-of-the-box UI components and API integration."
+          hashtags=["wallet", "open-source", "typescript"]
         )
         PortfolioItem(
           isFeatured=false


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/94

test: https://holdex-venture-studio-git-feat-update-a27f64-holdex-accelerator.vercel.app/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded tag collection for portfolio entries with various new tags.
	- Added new portfolio item for "Thirdweb Svelte" project.
	- Enhanced portfolio template with structured company and project content, including navigation and project details.

- **Bug Fixes**
	- Updated hashtags for Finoverse project.
	- Adjusted reservesInUsd value for the "USDX" project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->