### PR TITLE
feat(ui): message body is too long

### DIFF
--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -111,6 +111,7 @@ mixin social
           textarea(
             rows="{5}"
             required
+            maxlength="160"
             bind:value="{message}"
             class="relative w-full border border-solid border-l4 block min-h-32 h-32 bg-l1 shadow-input rounded-xl p-2.5 text-footnote text-t1 transition-all placeholder:text-footnote placeholder:opacity-100 placeholder:text-t3 hover:border-accent1-default autofill:fill-t1 autofill:hover:text-t3 dark:bg-l2"
             name="message"


### PR DESCRIPTION
ETA: 2 hours 
resolves: https://github.com/holdex/marketing/issues/93
test: https://holdex-venture-studio-fu1xuoe7w-holdex-accelerator.vercel.app/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added character limit of 160 characters to the contact form message textarea.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->