### PR TITLE
fix(ui):  correct table of contents spacing

### DIFF
--- a/src/routes/(pages)/c/[slug]/[messageSlug]/template.pug
+++ b/src/routes/(pages)/c/[slug]/[messageSlug]/template.pug
@@ -57,7 +57,7 @@ mixin author
         open="false"
         on:click|preventDefault="{toggleToc}"
         class:active="{tocOpen}"
-        class="flex w-full cursor-pointer flex-col items-start bg-l1 rounded-xl border border-solid border-l4 dark:bg-l2"
+        class="flex w-full cursor-pointer flex-col bg-l1 rounded-xl border border-solid border-l4 dark:bg-l2"
       )
         summary(class="flex items-center justify-between p-3.75 w-full")
           TextParagraph(class="pointer-events-none" textColor="text-t3") Table of Contents


### PR DESCRIPTION
ETA: 1 hour
resolves: https://github.com/holdex/holdex-venture-studio/issues/651#issuecomment-2597276838


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering of message details with conditional display of authors
	- Added navigation crumbs and message header
	- Improved Table of Contents display with clickable items
	- Conditional edit link for Google Docs

- **Bug Fixes**
	- Refined display logic for message metadata and content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->