### PR TITLE
feat: view website dark theme by default

### DIFF
--- a/src/lib/styles/theme.scss
+++ b/src/lib/styles/theme.scss
@@ -33,17 +33,8 @@
       font-family: var(--main-font);
     }
   }
-
-  @media (prefers-color-scheme: dark) {
-    :root {
-      @include colorScheme();
-    }
-  }
-
-  @media (prefers-color-scheme: light) {
-    :root {
-      @include colorScheme('light');
-    }
+  :root {
+    @include colorScheme();
   }
 
   [data-theme='dark'] {

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -32,13 +32,7 @@
   let success = false;
   let isBurgerDropdownShown = false;
   let theme = globalThis.localStorage?.getItem('theme') as 'dark' | 'light' | undefined | null;
-  let themeIconName: SVGIconName = theme
-    ? theme === 'dark'
-      ? 'sun'
-      : 'moon'
-    : globalThis.window?.matchMedia('(prefers-color-scheme: light)').matches
-    ? 'moon'
-    : 'sun';
+  let themeIconName: SVGIconName = theme ? (theme === 'dark' ? 'sun' : 'moon') : 'sun';
 
   let themeContext = writable(themeIconName === 'sun' ? 'dark' : 'light');
   setContext('theme', themeContext);


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/113

Test: https://holdex-venture-studio-git-dark-theme-default-holdex-accelerator.vercel.app/

I changed my system settings to light, and the website shows dark by default

https://github.com/user-attachments/assets/d87d9610-607b-4d71-8e3d-a8d906fdd24c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated theme color scheme initialization to always apply default color scheme
	- Simplified theme icon name selection logic in the layout component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->