### PR TITLE
feat: not view outdated consensus announcement banners

### DIFF
--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -116,7 +116,7 @@ mixin left-sidebar
       Link(item="{{type: 'heading-link', href: routes.jobs, iconSize: 24}}") Jobs
 
     div(class="h-15.5 relative")
-      +announcement-post-it("https://holdex.io/c/announcements/holdex-is-heading-to-consensus-in-hong-kong-meet-us-there", "Feb 18-20", "Hong Kong", "Meet us at Consensus!")
+      //- +announcement-post-it("https://holdex.io/c/announcements/holdex-is-heading-to-consensus-in-hong-kong-meet-us-there", "Feb 18-20", "Hong Kong", "Meet us at Consensus!")
 
 mixin right-sidebar
   aside.sidebar(
@@ -169,7 +169,7 @@ mixin header
                 type="button"
                 on:click!="{() => handleClick(undefined)}"
               )
-      +announcement-banner("https://holdex.io/c/announcements/holdex-is-heading-to-consensus-in-hong-kong-meet-us-there", "📣 Meet us at Consensus in Hong Kong, Feb 18-20!")
+      //- +announcement-banner("https://holdex.io/c/announcements/holdex-is-heading-to-consensus-in-hong-kong-meet-us-there", "📣 Meet us at Consensus in Hong Kong, Feb 18-20!")
 
 .app-container
   +header


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/179

Test: https://holdex-venture-studio-git-hide-consensus-holdex-accelerator.vercel.app/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed announcement elements from the header and sidebar, streamlining the visual layout for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->