### PR TITLE
feat: view renamed "Guide" as "Research"

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -62,7 +62,7 @@ export const routes = {
   forStartups: '/for-startups',
   studio: '/c',
   jobs: '/c/jobs',
-  guides: '/c/guides',
+  research: '/c/guides',
   category: (category: string | undefined) => `/c/${category}`,
   message: (category: string | undefined, message: string | undefined) =>
     `/c/${category}/${message}`,

--- a/src/routes/(pages)/c/guides/+page.svelte
+++ b/src/routes/(pages)/c/guides/+page.svelte
@@ -89,9 +89,9 @@
 </script>
 
 <MetaTags
-  title="Guides | Holdex"
+  title="Research | Holdex"
   description="Product and business crypto guides for someone who truly understands the power of blockchain."
-  path={routes.guides}
+  path={routes.research}
   imagePath="/og/index.png"
 />
 

--- a/src/routes/(pages)/c/guides/+page.svelte
+++ b/src/routes/(pages)/c/guides/+page.svelte
@@ -89,7 +89,7 @@
 </script>
 
 <MetaTags
-  title="Research | Holdex"
+  title="Research in Web3 created by Holdex Team"
   description="Product and business crypto guides for someone who truly understands the power of blockchain."
   path={routes.research}
   imagePath="/og/index.png"

--- a/src/routes/(pages)/c/guides/template.pug
+++ b/src/routes/(pages)/c/guides/template.pug
@@ -9,8 +9,8 @@ include ../../c/mixins
         +crumbDelimiter
         +crumbItemLink("/c", "Studio")
         +crumbDelimiter
-        +crumbItemText("Guides")
-      +messageHeader("Guides", "Product and business crypto guides for someone who truly understands the power of blockchain.")()
+        +crumbItemText("Research")
+      +messageHeader("Research", "Explore the thrilling realm of Web3 with Holdex's engaging insights on products and market trends—your guide to the future of the Internet!")()
       .card-wrapper(
         class="w-full grid grid-cols-2 smDown:grid-cols-1 gap-8 smDown:gap-4 auto-rows-max mt-2 mb-8 smDown:mb-4 smDown:mt-0"
       )

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -28,8 +28,8 @@ mixin main-nav
     +link("{routes.forStartups}", "For Startups")(
       class!="{isActive(path, routes.forStartups, true) ? 'before:!bg-accent1-default' : ''}"
     )
-    +link("{routes.guides}", "Guides")(
-      class!="{isActive(path, routes.guides, true) ? 'before:!bg-accent1-default' : ''}"
+    +link("{routes.research}", "Research")(
+      class!="{isActive(path, routes.research, true) ? 'before:!bg-accent1-default' : ''}"
     )
     +link("{routes.jobs}", "Jobs")(
       class!="{isActive(path, routes.jobs) ? 'before:!bg-accent1-default' : ''}"
@@ -112,7 +112,7 @@ mixin left-sidebar
       Link(item="{{type: 'heading-link', href: routes.about, iconSize: 24}}") About
       Link(item="{{type: 'heading-link', href: routes.portfolio, iconSize: 24}}") Portfolio
       Link(item="{{type: 'heading-link', href: routes.forStartups, iconSize: 24}}") For Startups
-      Link(item="{{type: 'heading-link', href: routes.guides, iconSize: 24}}") Guides
+      Link(item="{{type: 'heading-link', href: routes.research, iconSize: 24}}") Research
       Link(item="{{type: 'heading-link', href: routes.jobs, iconSize: 24}}") Jobs
 
     div(class="h-15.5 relative")


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/198

https://holdex-venture-studio-git-rename-rese-4f3eeb-holdex-accelerator.vercel.app/c/guides

Note that the tags, urls are still under /guides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Rebranded the “Guides” section to “Research” across the site.
  - Updated page titles, navigation links, breadcrumbs, and header descriptions to reflect the new naming while maintaining existing URL paths and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->