### PR TITLE
feat(api): parse endorsement data from Google Doc

### DIFF
--- a/src/lib/components/BodyParser/blocks.ts
+++ b/src/lib/components/BodyParser/blocks.ts
@@ -151,6 +151,14 @@ export type TestimonialElement = {
   content: string;
 };
 
+export type EndorsementElement = {
+  picture: null | Link;
+  name: string;
+  title: string;
+  content: string;
+  link: string;
+};
+
 type Link = {
   url: string;
   text: string;

--- a/src/routes/api/google-conversion/+server.ts
+++ b/src/routes/api/google-conversion/+server.ts
@@ -21,6 +21,7 @@ import type {
   CTAElement,
   TeamMemberBlock,
   TestimonialElement,
+  EndorsementElement,
 } from '$components/BodyParser/blocks';
 import type {
   Parsed$Paragraph,
@@ -56,8 +57,9 @@ export const POST: RequestHandler = async ({ request }) => {
  * content types:
  * - For paragraphs, it delegates processing to the `parseParagraph` function.
  * - For tables, it builds a nested content structure from table cells and attempts to extract team member
- *   data via `parseTeamMembersSection`, call-to-action (CTA) details via `parseCTASection`, or testimonials
- *   via `parseTestimonialSection`. The extracted content is added based on a prioritized check.
+ *   data via `parseTeamMembersSection`, call-to-action (CTA) details via `parseCTASection`,
+ *   endorsements via 'parseEndorsementsSection, or testimonials  via `parseTestimonialSection`.
+ *   The extracted content is added based on a prioritized check.
  * - For table of contents, it processes each paragraph entry to form a TOC block.
  *
  * The function returns a newly assembled array of content blocks structured for Holdex consumption.
@@ -122,6 +124,7 @@ function convertToHoldexJson(document: Schema$Document) {
         const teamMember = parseTeamMemberSection(tableContent);
         const cta: CTAElement = parseCTASection(tableContent);
         const testimonial: TestimonialElement = parseTestimonialSection(tableContent);
+        const endorsement: EndorsementElement = parseEndorsementSection(tableContent);
 
         if (!_.isEmpty(teamMember)) {
           newContent.push(teamMember);
@@ -134,6 +137,11 @@ function convertToHoldexJson(document: Schema$Document) {
           newContent.push({
             type: 'cta',
             data: cta,
+          });
+        } else if (!_.isEmpty(endorsement)) {
+          newContent.push({
+            type: 'endorsement',
+            data: endorsement,
           });
         } else {
           newContent.push({
@@ -250,6 +258,54 @@ function parseTestimonialSection(content: any[]) {
 }
 
 /**
+ * Parses a endorsement section from the provided content array.
+ *
+ * This function extracts endorsement data from a specific two-dimensional array structure. It expects the content array to have exactly 6 rows,
+ * each containing 2 elements. The header row must include a paragraph with the text "type" as its first element and a paragraph with the text "endorsement" as its second element.
+ * For each subsequent row, the function interprets the first element as the key and the second element as the corresponding value.
+ *
+ * The extracted key-value pairs are used to populate a EndorsementElement object with the following properties:
+ * - name: The name of the person giving the endorsement.
+ * - title: The title or role of the person.
+ * - content: The endorsement text.
+ * - picture: An object containing the person's name (as text) and the URL of their picture.
+ * - link: a URL to a page of the person giving the endorsement.
+ *
+ * If the content does not meet the expected structure, an empty EndorsementElement is returned.
+ *
+ * @param content - An array representing rows of endorsement data, where each row is an array of two elements with paragraph objects.
+ * @returns A populated EndorsementElement object if the expected structure is met; otherwise, an empty EndorsementElement.
+ */
+function parseEndorsementSection(content: any[]) {
+  const endorsement: EndorsementElement = {} as EndorsementElement;
+  if (content.length === 6 && (content[0] as any[]).length === 2) {
+    const contentHead = content[0];
+    if (
+      contentHead[0][0].type === 'paragraph' &&
+      contentHead[0][0].data.text === 'type' &&
+      contentHead[1][0].type === 'paragraph' &&
+      contentHead[1][0].data.text === 'endorsement'
+    ) {
+      const data: any = {};
+      content.forEach(([[first], [second]], i) => {
+        if (first === undefined || first.type !== 'paragraph') return;
+        if (second === undefined || second.type !== 'paragraph') data[first.data.text] = '';
+        else data[first.data.text] = second.data.text;
+      });
+      endorsement.name = data['name'];
+      endorsement.title = data['title'];
+      endorsement.content = data['content'];
+      endorsement.picture = {
+        text: data['name'],
+        url: data['picture'],
+      };
+      endorsement.link = data['link'];
+    }
+  }
+  return endorsement;
+}
+
+/**
  * Parses a team members section from table content and returns an array of team member blocks.
  *
  * The function expects the input to be an array of table rows, where each row is an array consisting of two cells.
@@ -273,7 +329,7 @@ function parseTeamMemberSection(content: any[]): TeamMemberBlock | null {
       contentHead[1][0]?.type === 'paragraph' &&
       contentHead[1][0]?.data?.text === 'teamMember'
     ) {
-      let currentMember: Record<string, string> = {};
+      const currentMember: Record<string, string> = {};
 
       for (const [[first], [second]] of content) {
         if (first?.type !== 'paragraph' || second?.type !== 'paragraph') continue;


### PR DESCRIPTION
Resolves: https://github.com/holdex/holdex-venture-studio/issues/732
ETA: 2Hrs

output:
```
{
    "type": "endorsement",
    "data": {
      "name": "Johnathan Kdoe",
      "title": "CEO, Co-Founder",
      "content": "Convallis est pretium fermentum porta vitae etiam consequat donec. Et eu diam nibh dolor quam. Varius eu mattis elit ante mattis eu commodo amet ullamcorper.",
      "picture": {
        "text": "Johnathan Kdoe",
        "url": "https://img.freepik.com/free-psd/3d-illustration-human-avatar-profile_23-2150671142.jpg?size=338&ext=jpg&ga=GA1.1.632798143.1705795200&semt=ais"
      },
      "link": "https://holdex.io"
    }
  }
```

Note: I created a separate parseEndorsementSection function instead of merging it with parseTestimonialSection to prioritize readability and maintainability. This makes future edits easier if we need to modify one without affecting the other, even though it’s slightly less DRY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced endorsement content support, enabling the system to process additional details such as images, names, titles, descriptions, and links.
  - Enhanced content processing to seamlessly include endorsements alongside existing content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->