### PR TITLE
chore(api): undo commit 337c0454716ebdcf3832724c69c67b30bb597e7f

### DIFF
--- a/src/lib/components/BodyParser/blocks.ts
+++ b/src/lib/components/BodyParser/blocks.ts
@@ -151,14 +151,6 @@ export type TestimonialElement = {
   content: string;
 };
 
-export type EndorsementElement = {
-  picture: null | Link;
-  name: string;
-  title: string;
-  content: string;
-  link: string;
-};
-
 type Link = {
   url: string;
   text: string;


### PR DESCRIPTION
This reverts commit 337c0454716ebdcf3832724c69c67b30bb597e7f.

Reverting this because it's not necessary. Will change testimonial parser to handle new link field in different pr. 

I'm not sure what the guidelines are for reverting, because there's nothing about it in the guidlines document. 

I can also create a new pull request where I remove these changes (commit 337c..) manually and add the new code for handling the parsing of the new testimonial component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed support for endorsement content; the application now processes only team member details, testimonials, and call-to-action elements.
	- This streamlining may affect layouts that previously rendered endorsement details, resulting in a more consistent presentation.
	- Users should note that any endorsement elements will no longer appear in content displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->