### PR TITLE
chore: view talk to us button

### DIFF
--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -127,10 +127,9 @@ mixin right-sidebar
   )
     button.w-fit.relative.my-1.underline.underline-offset-4.text-accent1-default.transition-colors(
       on:click!="{() => handleClick(undefined)}"
-      class="bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25"
+      class="bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25 text-h3-l xs:text-h3-s font-satoshi"
     )
-      h3
-        | Talk to Us!
+      | Talk to Us!
     +sidebar-social
     button.h-8.flex.items-center.gap-2(on:click!="{onThemeToggle}" class="group")
       SVGIcon(


### PR DESCRIPTION
test-url:- https://holdex-venture-studio-git-chore-view-navbar-holdex-accelerator.vercel.app/
- closes https://github.com/holdex/marketing/issues/246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the "Talk to Us!" button in the right sidebar with improved typography and font styling.

- **Refactor**
  - Simplified the button structure by removing the nested heading element and placing the text directly inside the button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->