### PR TITLE
chore: HashTag component

### DIFF
--- a/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/LinkPreview/index.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/LinkPreview/index.svelte
@@ -14,7 +14,7 @@
   let theme = getContext('theme');
 </script>
 
-<a class="exclude embed-link underline-not {$theme}" {href} target="_blank" rel="nofollow">
+<a class="exclude embed-link underline-not plain-link {$theme}" {href} target="_blank" rel="nofollow">
   {#if image}
     <span class="embed-link__image" class:relative={html}>
       <img src={image.url} alt="Website" />

--- a/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Tweet/TweetAction.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Tweet/TweetAction.svelte
@@ -36,7 +36,7 @@
 <template lang="pug">
   .border-t.border-tw-tweet-border
     .flex(class="mt-[0.2rem]") 
-      a.text-tw-tweet-link-color.block.text-sm.no-underline.px-5.like.exclude(
+      a.text-tw-tweet-link-color.block.text-sm.no-underline.px-5.like.exclude.plain-link(
         class="transition-[color] duration-[0.3s] ease-[ease-in-out] py-2.5 {$theme}"
         href="{tweetUrl}"
         title="Like"
@@ -51,7 +51,7 @@
         )
           p {likeCount}
 
-      a.text-tw-tweet-link-color.block.text-sm.no-underline.px-5.exclude(
+      a.text-tw-tweet-link-color.block.text-sm.no-underline.px-5.exclude.plain-link(
         class="transition-[color] duration-[0.3s] ease-[ease-in-out] py-2.5 {$theme}"
         href="{tweetUrl}"
         title="Like"
@@ -65,7 +65,7 @@
         )
           p Reply
 
-      a.text-tw-tweet-link-color.block.text-sm.no-underline.px-5.exclude(
+      a.text-tw-tweet-link-color.block.text-sm.no-underline.px-5.exclude.plain-link(
         class="transition-[color] duration-[0.3s] ease-[ease-in-out] py-2.5 {$theme}"
         href="{tweetUrl}"
         title="Like"
@@ -80,7 +80,7 @@
           p Copy Link
 
     .flex.items-center.justify-center
-      a.flex.items-center.justify-center.h-8.not-italic.font-bold.leading-8.text-sm.no-underline.px-5.text-tw-tweet-link-color.bg-tw-tweet-btn-color.border.border-tw-tweet-btn-border(
+      a.flex.items-center.justify-center.h-8.not-italic.font-bold.leading-8.text-sm.no-underline.px-5.text-tw-tweet-link-color.bg-tw-tweet-btn-color.border.border-tw-tweet-btn-border.plain-link(
         class="w-[95%] mb-[15px] rounded-[999px] transition-[color] duration-[0.3s] ease-[ease-in-out] py-2.5 hover:bg-transparent"
         href="{tweetUrl}"
         title="Read replies to tweet"

--- a/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Tweet/TweetHeader.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Tweet/TweetHeader.svelte
@@ -14,7 +14,7 @@
 <div class="flex">
   <a
     href={url}
-    class="avatar @apply h-9 w-9 mr-2.5 exclude {$theme}"
+    class="avatar @apply h-9 w-9 mr-2.5 exclude plain-link {$theme}"
     target="_blank"
     rel="noopener noreferrer"
   >
@@ -22,7 +22,7 @@
   </a>
   <a
     href={url}
-    class="author no-underline text-inherit transition-[color] duration-[0.3s] ease-[ease-in-out] exclude {$theme}"
+    class="author no-underline text-inherit transition-[color] duration-[0.3s] ease-[ease-in-out] exclude plain-link {$theme}"
     target="_blank"
     rel="noopener noreferrer"
   >
@@ -41,7 +41,7 @@
   </a>
   <a href={url} class="brand exclude" target="_blank" rel="noopener noreferrer">
     <img
-      class="icon w-[1.25em] h-[1.25em] object-contain twicon"
+      class="icon w-[1.25em] h-[1.25em] object-contain twicon plain-link"
       title="View on Twitter"
       alt="twitter"
       src="/tweet/twitter.png"

--- a/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Tweet/TweetInfo.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Tweet/TweetInfo.svelte
@@ -17,7 +17,7 @@
 <div class="text-sm flex">
   {#if createdAt}
     <a
-      class="inter text-tw-tweet-color-gray no-underline not-italic font-medium text-sm leading-5 focus:underline exclude hover:text-tw-tweet-link-color-hover {$theme}"
+      class="inter text-tw-tweet-color-gray no-underline not-italic font-medium text-sm leading-5 focus:underline exclude hover:text-tw-tweet-link-color-hover plain-link {$theme}"
       href={tweetUrl}
       target="_blank"
       rel="noopener noreferrer"

--- a/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Twitter/link.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/Twitter/link.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <a
-  class="inline-block no-underline text-tw-tweet-link-color hover:underline exclude {$theme}"
+  class="plain-link text-tw-tweet-link-color hover:underline exclude {$theme}"
   {href}
   target="_blank"
   rel="noopener noreferrer"

--- a/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/anchor.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/Tweet/components/twitter-layout/anchor.svelte
@@ -32,7 +32,7 @@
   target="_blank"
   rel="noopener noreferrer"
   title={title || href}
-  class="inline-block no-underline hover:underline exclude text-tw-tweet-link-color {$theme}"
+  class="plain-link hover:underline exclude text-tw-tweet-link-color {$theme}"
 >
   {beautifyHref(value)}
 </a>

--- a/src/lib/components/BodyRenderer/Blocks/hashtag.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/hashtag.svelte
@@ -11,7 +11,7 @@
 
   let classes = `relative inline-block text-accent1-default transition-colors ${
     link
-      ? 'underline underline-offset-4 bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25'
+      ? 'bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25'
       : 'bg-transparent hover:bg-transparent'
   }`;
 

--- a/src/lib/components/BodyRenderer/Blocks/hashtag.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/hashtag.svelte
@@ -9,22 +9,19 @@
   export let item: Item;
   export let link: string | undefined = undefined;
 
-  let classes = `relative inline-block text-accent1-default transition-colors ${
-    link
-      ? 'bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25'
-      : 'bg-transparent hover:bg-transparent'
-  }`;
-
   $: text = item.text || item.href;
 </script>
 
 {' '}
 {#if link}
-  <a title={item.title ? item.title : ''} href={link} class={classes} rel="noreferrer">
+  <a title={item.title ? item.title : ''} href={link} rel="noreferrer">
     <slot {text} />
   </a>
 {:else}
-  <span title={item.title ? item.title : ''} class={classes}>
+  <span
+    title={item.title ? item.title : ''}
+    class="relative inline-block text-accent1-default transition-colors"
+  >
     <slot {text} />
   </span>
 {/if}

--- a/src/lib/components/BodyRenderer/Blocks/link.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/link.svelte
@@ -63,7 +63,6 @@
   target={isHoldexLink || isInternalLink ? '_self' : '_blank'}
   rel="noreferrer"
   on:click={(e) => handleClick(e, item.href)}
-  class="underline underline-offset-4"
 >
   <slot text={truncated} />
 </a>

--- a/src/lib/components/BodyRenderer/Blocks/linkBlock.svelte
+++ b/src/lib/components/BodyRenderer/Blocks/linkBlock.svelte
@@ -65,7 +65,7 @@
   title={title ? title : ''}
   target={isHoldexLink ? '_self' : '_blank'}
   rel="noreferrer"
-  class="block w-full h-[96px] border-solid border border-l4 rounded-xl shadow-accent1-default overflow-hidden active:border-accent1-default focus:border-accent1-default hover:bg-l3 dark:hover:bg-l3 transition-colors duration-100 ease-in-out"
+  class="block w-full h-[96px] border-solid border border-l4 rounded-xl shadow-accent1-default overflow-hidden active:border-accent1-default focus:border-accent1-default hover:bg-l3 dark:hover:bg-l3 transition-colors duration-100 ease-in-out plain-link"
 >
   <div class="flex items-center gap-4 w-full h-full">
     {#if isLoading}

--- a/src/lib/components/Button/template.pug
+++ b/src/lib/components/Button/template.pug
@@ -12,7 +12,7 @@ mixin content
   slot
 
 +if('href')
-  a.no-underline(
+  a.plain-link(
     {...$$restProps}
     use:forwardAction
     disabled="{disabled}"

--- a/src/lib/components/Feed/ResourceItem/template.pug
+++ b/src/lib/components/Feed/ResourceItem/template.pug
@@ -7,8 +7,6 @@ article.block(class!="{className}")
       +each('message.hashtags as tag, index')
         +if('index !== 0')
           li.text-paragraph-l(class="text-t3/50") &bull;
-        li.underline.underline-offset-4.text-accent1-default.text-inter.h-8.text-paragraph-l(
-          class="bg-accent1-default/15"
-        )
+        li.text-inter.h-8.text-paragraph-l
           Hashtag(item="{tag}" link="/c?filter={tag}") 
             | {'#'}{tag}

--- a/src/lib/components/TeamMemberCard/template.pug
+++ b/src/lib/components/TeamMemberCard/template.pug
@@ -10,7 +10,7 @@ article.flex.flex-col.w-full(class="smDown:flex-col smDown:items-start")
         +if('link && link.length > 0')
           a(
             href="{link}"
-            class="relative text-h4-s xs:text-h5-s font-satoshi inline-block w-fit underline underline-offset-4 bg-accent1-default/15 text-accent1-default transition-colors hover:bg-accent1-default/25 focus:bg-accent1-default/25"
+            class="text-h4-s xs:text-h5-s font-satoshi"
             target="_blank"
             rel="noopener noreferrer"
           )

--- a/src/lib/styles/theme.scss
+++ b/src/lib/styles/theme.scss
@@ -64,7 +64,7 @@
   }
 
   .plain-link {
-    @apply bg-transparent hover:bg-transparent focus:bg-transparent font-inherit text-inherit;
+    @apply bg-transparent hover:bg-transparent focus:bg-transparent font-inherit text-inherit no-underline;
     display: inline;
   }
 

--- a/src/lib/styles/theme.scss
+++ b/src/lib/styles/theme.scss
@@ -46,7 +46,7 @@
   }
 
   a {
-    @apply font-inherit inline-block w-fit relative bg-accent1-default/15 text-accent1-default transition-colors hover:bg-accent1-default/25 focus:bg-accent1-default/25;
+    @apply font-inherit inline-block w-fit relative bg-accent1-default/15 text-accent1-default transition-colors hover:bg-accent1-default/25 focus:bg-accent1-default/25 underline underline-offset-4;
   }
 
   a[href^='http']::after {

--- a/src/routes/(pages)/c/mixins.pug
+++ b/src/routes/(pages)/c/mixins.pug
@@ -42,17 +42,14 @@ mixin short-links
 
 mixin short-link(href, icon, title)
   a.short-link(
-    class="flex items-center gap-2 text-cta text-t1 transition-colors hover:text-accent1-default"
+    class="flex items-center gap-2 text-cta text-t1 transition-colors hover:text-accent1-default plain-link"
     href=href
   )
     Icon(icon=icon width="{20}" height="{20}" colorInherit)
     span= title
 
 mixin inline-link(href, title)
-  a.short-link(
-    class="relative underline underline-offset-4 bg-accent1-default/15 text-accent1-default text-paragraph-l transition-colors hover:bg-accent1-default/25 focus:bg-accent1-default/25"
-    href=href
-  )&attributes(attributes)
+  a.short-link.text-paragraph-l(href=href)&attributes(attributes)
     span= title
 
 mixin button-secondary-small(label)

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -80,7 +80,7 @@ mixin sidebar-social
     )
 
 mixin announcement-post-it(href, date, location, content)
-  a.absolute.bottom-0.-rotate-6.transform(
+  a.absolute.bottom-0.-rotate-6.transform.plain-link(
     href=href
     target="_blank"
     class="hover:-rotate-[4deg] transition-transform duration-300"

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -102,7 +102,7 @@ mixin announcement-banner(href, text)
     a(
       href=href
       target="_blank"
-      class="text-t1 text-paragraph-s hover:text-accent1-default transition-colors text-start sm-up:text-center w-full text-wrap leading-6"
+      class="text-t1 text-paragraph-s hover:text-accent1-default transition-colors text-start sm-up:text-center w-full text-wrap leading-6 plain-link"
     )= text
 
 mixin left-sidebar

--- a/src/routes/(pages)/link-refactoring/+page.svelte
+++ b/src/routes/(pages)/link-refactoring/+page.svelte
@@ -43,13 +43,15 @@
   <h3><Link item={link3} let:text>{text}</Link></h3>
   <h3><Link item={link4} let:text>{text}</Link></h3>
 
-  These links are rendered using the direct <code>&lt;a&gt;</code> HTML element:
+  These links are rendered using the direct<code>&lt;a&gt;</code> HTML element:
   <br />
   <h1>Heading h1 <a href="/about">About internal page</a></h1>
   <h2>Heading h2 <a href="https://google.com">Google external page</a></h2>
   <p>
     Link inside paragraph <a href="https://google.com">Google external page</a>
   </p>
-  <p class='mb-2'>Link Block Component</p>
-  <LinkBlock item={{title: "link", url: 'http://holdex.io', description: 'link block', imageUrl: null}}/>
+  <p class="mb-2">Link Block Component</p>
+  <LinkBlock
+    item={{ title: 'link', url: 'http://holdex.io', description: 'link block', imageUrl: null }}
+  />
 </div>

--- a/src/routes/(pages)/link-refactoring/+page.svelte
+++ b/src/routes/(pages)/link-refactoring/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Link from '$components/BodyRenderer/Blocks/link.svelte';
+  import LinkBlock from '$components/BodyRenderer/Blocks/linkBlock.svelte';
 
   type Item = {
     text: string;
@@ -49,4 +50,6 @@
   <p>
     Link inside paragraph <a href="https://google.com">Google external page</a>
   </p>
+  <p class='mb-2'>Link Block Component</p>
+  <LinkBlock item={{title: "link", url: 'http://holdex.io', description: 'link block', imageUrl: null}}/>
 </div>


### PR DESCRIPTION
test-url:- https://holdex-venture-studio-git-chore-op-link-comp-holdex-accelerator.vercel.app/
closes: https://github.com/holdex/marketing/issues/246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
  - Updated link styling to improve consistency, with standard links now underlined and plain links displaying without underlines.
  - Removed underline decoration and accent background from hashtag elements to create a cleaner visual presentation.
  - Applied the new plain-link style across various components and mixins for uniform link appearance.
  - Introduced the LinkBlock component displaying link details with consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->