### PR TITLE
feat: manage announcement banner with json file

### DIFF
--- a/src/lib/config/announcement.json
+++ b/src/lib/config/announcement.json
@@ -1,0 +1,14 @@
+{
+  "banner": {
+    "show": true,
+    "href": "/schedule-meeting",
+    "text": "📣 Join us at Coinfest Asia 2025, Aug 21-22!"
+  },
+  "post_it": {
+    "show": true,
+    "href": "/schedule-meeting",
+    "date": "Aug 21-22",
+    "location": "Bali",
+    "content": "Meet us at Coinfest Asia 2025!"
+  }
+}

--- a/src/lib/config/banner.json
+++ b/src/lib/config/banner.json
@@ -1,0 +1,5 @@
+{
+  "show": true,
+  "href": "https://x.com/HoldexIo/status/1903294773970211241",
+  "text": "📣 Join us at the Hong Kong Web3 Festival, Apr 6-9!"
+}

--- a/src/lib/config/banner.json
+++ b/src/lib/config/banner.json
@@ -1,5 +1,0 @@
-{
-  "show": true,
-  "href": "https://x.com/HoldexIo/status/1903294773970211241",
-  "text": "📣 Join us at the Hong Kong Web3 Festival, Apr 6-9!"
-}

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -60,6 +60,7 @@ export const routes = {
   apply: '/apply',
   portfolio: '/portfolio',
   forStartups: '/for-startups',
+  scheduleMeeting: '/schedule-meeting',
   studio: '/c',
   jobs: '/c/jobs',
   research: '/c/guides',

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -171,7 +171,7 @@
   }
 
   const isExternalLink = (href: string) => {
-    return regExp.holdexLink.test(href) || regExp.internalLink.test(href);
+    return !(regExp.holdexLink.test(href) || regExp.internalLink.test(href));
   };
 
   $: banner = data?.announcement?.banner

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -28,7 +28,6 @@
   import Link from '$components/BodyRenderer/Blocks/link.svelte';
 
   export let data;
-  const { banner } = data;
 
   let email = '';
   let message = '';
@@ -172,7 +171,7 @@
   }
 </script>
 
-<template lang="pug" src="./layout.pug" locals={banner}>
+<template lang="pug" src="./layout.pug">
 </template>
 
 <svelte:head>

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -170,25 +170,37 @@
     document.documentElement.dataset.theme = themeIconName === 'moon' ? 'light' : 'dark';
   }
 
-  $: banner = data &&
-    data.announcement && {
-      ...data.announcement.banner,
-      target:
-        regExp.holdexLink.test(data.announcement.banner.href) ||
-        regExp.internalLink.test(data.announcement.banner.href)
-          ? '_self'
-          : '_blank',
-    };
+  const isExternalLink = (href: string) => {
+    return regExp.holdexLink.test(href) || regExp.internalLink.test(href);
+  };
 
-  $: postIt = data &&
-    data.announcement && {
-      ...data.announcement.post_it,
-      target:
-        regExp.holdexLink.test(data.announcement.post_it.href) ||
-        regExp.internalLink.test(data.announcement.post_it.href)
-          ? '_self'
-          : '_blank',
-    };
+  $: banner = data?.announcement?.banner
+    ? {
+        ...data.announcement.banner,
+        target:
+          data.announcement.banner?.href && isExternalLink(data.announcement.banner.href)
+            ? '_blank'
+            : '_self',
+        rel:
+          data.announcement.banner?.href && isExternalLink(data.announcement.banner.href)
+            ? 'noopener noreferrer'
+            : undefined,
+      }
+    : undefined;
+
+  $: postIt = data?.announcement?.post_it
+    ? {
+        ...data.announcement.post_it,
+        target:
+          data.announcement.post_it?.href && isExternalLink(data.announcement.post_it.href)
+            ? '_blank'
+            : '_self',
+        rel:
+          data.announcement.post_it?.href && isExternalLink(data.announcement.post_it.href)
+            ? 'noopener noreferrer'
+            : undefined,
+      }
+    : undefined;
 </script>
 
 <template lang="pug" src="./layout.pug">

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -169,6 +169,26 @@
   $: if (globalThis.document) {
     document.documentElement.dataset.theme = themeIconName === 'moon' ? 'light' : 'dark';
   }
+
+  $: banner = data &&
+    data.announcement && {
+      ...data.announcement.banner,
+      target:
+        regExp.holdexLink.test(data.announcement.banner.href) ||
+        regExp.internalLink.test(data.announcement.banner.href)
+          ? '_self'
+          : '_blank',
+    };
+
+  $: postIt = data &&
+    data.announcement && {
+      ...data.announcement.post_it,
+      target:
+        regExp.holdexLink.test(data.announcement.post_it.href) ||
+        regExp.internalLink.test(data.announcement.post_it.href)
+          ? '_self'
+          : '_blank',
+    };
 </script>
 
 <template lang="pug" src="./layout.pug">

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -27,6 +27,9 @@
   import type { SVGIconName } from '$components/Icons/types';
   import Link from '$components/BodyRenderer/Blocks/link.svelte';
 
+  export let data;
+  const { banner } = data;
+
   let email = '';
   let message = '';
   let name = '';
@@ -169,7 +172,7 @@
   }
 </script>
 
-<template lang="pug" src="./layout.pug">
+<template lang="pug" src="./layout.pug" locals={banner}>
 </template>
 
 <svelte:head>

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -81,10 +81,11 @@ mixin sidebar-social
       class="!h-16 !w-16 !p-0 text-i1"
     )
 
-mixin announcement-post-it(href, date, location, content, target)
+mixin announcement-post-it(href, date, location, content, target, rel)
   a.absolute.bottom-0.-rotate-6.transform.plain-link(
     href=href
     target=target
+    rel=rel
     class="hover:-rotate-[4deg] transition-transform duration-300"
   )
     .w-45.bg-post-it-yellow.pr-3.py-4.pl-4.relative(class="shadow-xl")
@@ -97,7 +98,7 @@ mixin announcement-post-it(href, date, location, content, target)
         if content
           p.font-handwriting.text-black.text-h2-l.font-normal.pt-2(class="!text-[29.5px]")= content
 
-mixin announcement-banner(href, text, target)
+mixin announcement-banner(href, text, target, rel)
   if text && href
     .announcement-banner(
       class="w-full border-b border-solid border-l4 bg-l2 flex items-center justify-center px-4 py-3 gap-4"
@@ -105,6 +106,7 @@ mixin announcement-banner(href, text, target)
       a(
         href=href
         target=target
+        rel=rel
         class="text-t1 text-paragraph-s hover:text-accent1-default transition-colors text-start sm-up:text-center w-full text-wrap leading-6 plain-link"
       )= text
 
@@ -129,7 +131,7 @@ mixin left-sidebar
 
     div(class="h-15.5 relative")
       +if("postIt.show")
-        +announcement-post-it("{postIt.href}", "{postIt.date}", "{postIt.location}", "{postIt.content}", "{postIt.target}")
+        +announcement-post-it("{postIt.href}", "{postIt.date}", "{postIt.location}", "{postIt.content}", "{postIt.target}", "{postIt.rel}")
 
 mixin right-sidebar
   aside.sidebar(
@@ -216,7 +218,7 @@ mixin header
               on:click!="{() => handleClick(undefined)}"
             )
     +if("banner.show")
-      +announcement-banner("{banner.href}", "{banner.text}", "{banner.target}")
+      +announcement-banner("{banner.href}", "{banner.text}", "{banner.target}", "{banner.rel}")
 .app-container
   +header
   .flex(class="xl-up:w-full justify-center")

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -125,7 +125,7 @@ mixin left-sidebar
           Link(item="{{href: routes.jobs}}") Jobs
 
     div(class="h-15.5 relative")
-    //  +announcement-post-it("https://x.com/HoldexIo/status/1903294773970211241", "Apr 6-9", "Hong Kong", "Meet us at Web3 Festival!")
+      +announcement-post-it("https://x.com/HoldexIo/status/1903294773970211241", "Apr 6-9", "Hong Kong", "Meet us at Web3 Festival!")
 
 mixin right-sidebar
   aside.sidebar(
@@ -211,8 +211,8 @@ mixin header
               type="button"
               on:click!="{() => handleClick(undefined)}"
             )
-    // +announcement-banner("https://x.com/HoldexIo/status/1903294773970211241", "📣 Join us at the Hong Kong Web3 Festival, Apr 6-9!")
-
+    if "{data.banner.show}"
+      +announcement-banner("{data.banner.href}", "{data.banner.text}")
 .app-container
   +header
   .flex(class="xl-up:w-full justify-center")

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -96,14 +96,15 @@ mixin announcement-post-it(href, date, location, content)
           p.font-handwriting.text-black.text-h2-l.font-normal.pt-2(class="!text-[29.5px]")= content
 
 mixin announcement-banner(href, text)
-  .announcement-banner(
-    class="w-full border-b border-solid border-l4 bg-l2 flex items-center justify-center px-4 py-3 gap-4"
-  )
-    a(
-      href=href
-      target="_blank"
-      class="text-t1 text-paragraph-s hover:text-accent1-default transition-colors text-start sm-up:text-center w-full text-wrap leading-6 plain-link"
-    )= text
+  if text && href
+    .announcement-banner(
+      class="w-full border-b border-solid border-l4 bg-l2 flex items-center justify-center px-4 py-3 gap-4"
+    )
+      a(
+        href=href
+        target="_blank"
+        class="text-t1 text-paragraph-s hover:text-accent1-default transition-colors text-start sm-up:text-center w-full text-wrap leading-6 plain-link"
+      )= text
 
 mixin left-sidebar
   aside.sidebar(
@@ -125,7 +126,8 @@ mixin left-sidebar
           Link(item="{{href: routes.jobs}}") Jobs
 
     div(class="h-15.5 relative")
-      +announcement-post-it("https://x.com/HoldexIo/status/1903294773970211241", "Apr 6-9", "Hong Kong", "Meet us at Web3 Festival!")
+      +if('data.announcement.post_it.show')
+        +announcement-post-it("{data.announcement.post_it.href}", "{data.announcement.post_it.date}", "{data.announcement.post_it.location}", "{data.announcement.post_it.content}")
 
 mixin right-sidebar
   aside.sidebar(
@@ -211,8 +213,8 @@ mixin header
               type="button"
               on:click!="{() => handleClick(undefined)}"
             )
-    if "{data.banner.show}"
-      +announcement-banner("{data.banner.href}", "{data.banner.text}")
+    +if('data.announcement.banner.show')
+      +announcement-banner("{data.announcement.banner.href}", "{data.announcement.banner.text}")
 .app-container
   +header
   .flex(class="xl-up:w-full justify-center")

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -57,7 +57,9 @@ mixin social
     +social-link("https://twitter.com/HoldexIo", "{@html socialIcons.twitter}")(
       class="!h-5 !w-5 !p-0 text-i1"
     )
-    +social-link("https://t.me/holdex", "{@html socialIcons.telegram}")(class="!h-5 !w-5 !p-0 text-i1")
+    +social-link("https://t.me/holdex", "{@html socialIcons.telegram}")(
+      class="!h-5 !w-5 !p-0 text-i1"
+    )
 
 mixin sidebar-social
   .social-icons-nav(
@@ -79,10 +81,10 @@ mixin sidebar-social
       class="!h-16 !w-16 !p-0 text-i1"
     )
 
-mixin announcement-post-it(href, date, location, content)
+mixin announcement-post-it(href, date, location, content, target)
   a.absolute.bottom-0.-rotate-6.transform.plain-link(
     href=href
-    target="_blank"
+    target=target
     class="hover:-rotate-[4deg] transition-transform duration-300"
   )
     .w-45.bg-post-it-yellow.pr-3.py-4.pl-4.relative(class="shadow-xl")
@@ -95,14 +97,14 @@ mixin announcement-post-it(href, date, location, content)
         if content
           p.font-handwriting.text-black.text-h2-l.font-normal.pt-2(class="!text-[29.5px]")= content
 
-mixin announcement-banner(href, text)
+mixin announcement-banner(href, text, target)
   if text && href
     .announcement-banner(
       class="w-full border-b border-solid border-l4 bg-l2 flex items-center justify-center px-4 py-3 gap-4"
     )
       a(
         href=href
-        target="_blank"
+        target=target
         class="text-t1 text-paragraph-s hover:text-accent1-default transition-colors text-start sm-up:text-center w-full text-wrap leading-6 plain-link"
       )= text
 
@@ -126,8 +128,8 @@ mixin left-sidebar
           Link(item="{{href: routes.jobs}}") Jobs
 
     div(class="h-15.5 relative")
-      +if('data.announcement.post_it.show')
-        +announcement-post-it("{data.announcement.post_it.href}", "{data.announcement.post_it.date}", "{data.announcement.post_it.location}", "{data.announcement.post_it.content}")
+      +if("postIt.show")
+        +announcement-post-it("{postIt.href}", "{postIt.date}", "{postIt.location}", "{postIt.content}", "{postIt.target}")
 
 mixin right-sidebar
   aside.sidebar(
@@ -213,8 +215,8 @@ mixin header
               type="button"
               on:click!="{() => handleClick(undefined)}"
             )
-    +if('data.announcement.banner.show')
-      +announcement-banner("{data.announcement.banner.href}", "{data.announcement.banner.text}")
+    +if("banner.show")
+      +announcement-banner("{banner.href}", "{banner.text}", "{banner.target}")
 .app-container
   +header
   .flex(class="xl-up:w-full justify-center")

--- a/src/routes/(pages)/schedule-meeting/+page.svelte
+++ b/src/routes/(pages)/schedule-meeting/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import MetaTags from '$components/MetaTags/index.svelte';
+  import { routes } from '$lib/config';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    (function (C, A, L) {
+      let p = function (a, ar) {
+        a.q.push(ar);
+      };
+      let d = C.document;
+      C.Cal =
+        C.Cal ||
+        function () {
+          let cal = C.Cal;
+          let ar = arguments;
+          if (!cal.loaded) {
+            cal.ns = {};
+            cal.q = cal.q || [];
+            d.head.appendChild(d.createElement('script')).src = A;
+            cal.loaded = true;
+          }
+          if (ar[0] === L) {
+            const api = function () {
+              p(api, arguments);
+            };
+            const namespace = ar[1];
+            api.q = api.q || [];
+            if (typeof namespace === 'string') {
+              cal.ns[namespace] = cal.ns[namespace] || api;
+              p(cal.ns[namespace], ar);
+              p(cal, ['initNamespace', namespace]);
+            } else p(cal, ar);
+            return;
+          }
+          p(cal, ar);
+        };
+    })(window, 'https://app.cal.com/embed/embed.js', 'init');
+    Cal('init', '30min', { origin: 'https://app.cal.com' });
+
+    Cal.ns['30min']('inline', {
+      elementOrSelector: '#my-cal-inline-30min',
+      config: { layout: 'month_view' },
+      calLink: 'zolotokrylin/30min'
+    });
+
+    Cal.ns['30min']('ui', {
+      theme: 'dark',
+      cssVarsPerTheme: {
+        light: { 'cal-brand': '#11141E' },
+        dark: { 'cal-brand': '#ffffff' }
+      },
+      hideEventTypeDetails: false,
+      layout: 'month_view'
+    });
+  });
+</script>
+
+<MetaTags
+  title="Schedule Meeting"
+  description="Schedule a meeting with us to discuss your startup's needs"
+  path={routes.scheduleMeeting}
+/>
+
+
+<template lang="pug" src="./template.pug"></template>

--- a/src/routes/(pages)/schedule-meeting/template.pug
+++ b/src/routes/(pages)/schedule-meeting/template.pug
@@ -1,0 +1,10 @@
+include ../common-mixins
+include ../c/mixins
++main-section
+  +header-wrapper.flex-col.gap-8(class="xs:gap-4")
+    +nav-crumbs
+      +crumbItemLink("/", "Holdex")
+      +crumbDelimiter
+      +crumbItemText("Schedule Meeting")
+    h1.text-title-l.font-satoshi.text-center(class="smDown:text-left xs:text-h1-s") Schedule Meeting
+    .w-full(id="my-cal-inline-30min")

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -2,7 +2,7 @@ import { VERCEL_URL } from '$env/static/private';
 import config from '$lib/config';
 import { dev, building } from '$app/environment';
 import type { LayoutServerLoad } from './$types';
-import banner from '$lib/config/banner.json';
+import announcement from '$lib/config/announcement.json';
 
 export const load: LayoutServerLoad = () => {
   let url = '';
@@ -19,6 +19,6 @@ export const load: LayoutServerLoad = () => {
 
   return {
     deploymentUrl: url,
-    banner,
+    announcement,
   };
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -2,6 +2,7 @@ import { VERCEL_URL } from '$env/static/private';
 import config from '$lib/config';
 import { dev, building } from '$app/environment';
 import type { LayoutServerLoad } from './$types';
+import banner from '$lib/config/banner.json';
 
 export const load: LayoutServerLoad = () => {
   let url = '';
@@ -18,5 +19,6 @@ export const load: LayoutServerLoad = () => {
 
   return {
     deploymentUrl: url,
+    banner,
   };
 };


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/208

https://holdex-venture-studio-git-announcement-holdex-accelerator.vercel.app/schedule-meeting

announcement can be managed through: `/lib/config/announcement.json` file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Schedule Meeting page at /schedule-meeting with an embedded Cal.com 30‑minute booking widget, dark-theme styling, and SEO metadata.
  * Added configurable announcements (banner and post‑it) with visibility toggles, content fields, and dynamic link target behavior.
  * Layout now surfaces the configured announcements when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->