### PR TITLE
chore: view updated page subtitle typography

### DIFF
--- a/src/routes/(pages)/c/mixins.pug
+++ b/src/routes/(pages)/c/mixins.pug
@@ -79,7 +79,7 @@ mixin messageHeader(title, subtitle, cover = null)
       class="w-full h-auto object-contain box-border border border-solid border-l4 rounded-xl"
     )
   if subtitle
-    p(class="text-subtitle-xl text-t2 text-center smDown:text-left xs:text-subtitle-s w-full")= subtitle
+    p(class="text-subtitle-l text-t2 text-center smDown:text-left xs:text-subtitle-s w-full")= subtitle
 
 mixin feedRenderer
   +if("isSearchMode")


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/307

https://holdex-venture-studio-git-fix-subtitl-b232e7-holdex-accelerator.vercel.app/portfolio
https://holdex-venture-studio-git-fix-subtitl-b232e7-holdex-accelerator.vercel.app/c/guides
https://holdex-venture-studio-git-fix-subtitl-b232e7-holdex-accelerator.vercel.app/c/jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated subtitle typography in message headers to a slightly smaller size for improved visual hierarchy and readability.
  * Standardized subtitle styling for a more consistent look across related pages.
  * No impact to titles, cover imagery, or layout; only subtitle appearance is adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->