### PR TITLE
chore: update typography and spacing in link components

### DIFF
--- a/src/lib/components/Feed/ResourceItem/template.pug
+++ b/src/lib/components/Feed/ResourceItem/template.pug
@@ -1,5 +1,5 @@
 article.block(class!="{className}")
-  h3(class="mb-3.625 smDown:mb-3.25 leading-[29px] text-underline-offset-1")
+  h3(class="mb-3.625 smDown:mb-3.25 item-title ")
     Link(item="{{href: '/c/'+message.communitySlug+'/'+message.messageSlug}}") {message.title}
   TextParagraph(class="mb-7.25 smDown:mb-4 text-t2") {message.subtitle}
   +if('message.hashtags && message.hashtags.length > 0')

--- a/src/lib/components/Portfolio/template.pug
+++ b/src/lib/components/Portfolio/template.pug
@@ -66,7 +66,7 @@ article.portfolio-product-card(
 )
   .portfolio-product-body(class="flex flex-col w-full gap-7.25 smDown:gap-4")
     div(class="relative flex flex-col w-full gap-3.625 smDown:gap-3.25")
-      h3(class="portfolio-product-title leading-[29px]")
+      h3(class="item-title")
         Link(item="{{href: slug, text: title, title: title}}")= `{title}`
       TextParagraph {subtitle}
 

--- a/src/lib/styles/theme.scss
+++ b/src/lib/styles/theme.scss
@@ -63,8 +63,8 @@
   a[href^='http']::after {
     content: '';
     display: inline-block;
-    width: 0.9em;
-    height: 0.9em;
+    width: 1em;
+    height: 1em;
     margin-left: 0.2em;
     vertical-align: middle;
     background-color: currentColor;

--- a/src/lib/styles/theme.scss
+++ b/src/lib/styles/theme.scss
@@ -116,16 +116,18 @@
   }
 
   .sidebar-nav {
-    @apply text-h3-l leading-[29px] font-satoshi;
+    @apply text-h3-l font-satoshi;
 
     a {
-      @apply underline-offset-1;
+      @apply underline-offset-7.25;
     }
   }
 
-  .portfolio-product-title {
+  .item-title {
+    @apply font-satoshi;
+
     a {
-      @apply underline-offset-1 h-[29px];
+      @apply md-up:underline-offset-7.25;
     }
   }
 }

--- a/src/routes/(pages)/layout.pug
+++ b/src/routes/(pages)/layout.pug
@@ -117,7 +117,7 @@ mixin left-sidebar
   )
     a(class="relative flex h-10 w-38.5 plain-link" href="{routes.index}"): SVGIcon(name="logo" class="")
     nav
-      ul.sidebar-nav(class="flex flex-col gap-7.25 w-full shrink-0")
+      ul.sidebar-nav(class="flex flex-col gap-3.625 w-full shrink-0")
         li(class="font-inherit")
           Link(item="{{href: routes.about}}") About
         li(class="font-inherit")
@@ -138,9 +138,9 @@ mixin right-sidebar
     class="hidden xl-up:flex shrink-0 flex-col items-end justify-between w-70 sticky top-0 h-screen py-14.5 pl-7.25 pr-14.5"
     class!=attributes.class
   )
-    button.w-fit.relative.underline.underline-offset-1.text-accent1-default.transition-colors(
+    button.w-fit.relative.underline.text-accent1-default.transition-colors(
       on:click!="{() => handleClick(undefined)}"
-      class="bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25 text-h3-l font-satoshi leading-[29px]"
+      class="bg-accent1-default/15 hover:bg-accent1-default/25 focus:bg-accent1-default/25 text-h3-l font-satoshi underline-offset-7.25"
     )
       | Talk to Us!
     +sidebar-social
@@ -171,7 +171,7 @@ mixin header
             )
           div(
             id="secondary-navbar"
-            class!="relative z-[11] bg-l1 overflow-x-scroll scrollbar-hide w-full flex tb-up:pl-4 [mask-image:_linear-gradient(to_right,transparent_0,_black_24px,_black_calc(100%-24px),transparent_100%)]"
+            class!="relative z-[11] bg-l1 overflow-x-scroll scrollbar-hide w-full flex tb-up:pl-4 h-full [mask-image:_linear-gradient(to_right,transparent_0,_black_24px,_black_calc(100%-24px),transparent_100%)]"
           )
             div(
               id="secondary-navbar-section h-full"


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/293

https://holdex-venture-studio-git-fix-nav-links-holdex-accelerator.vercel.app/portfolio
https://holdex-venture-studio-git-fix-nav-links-holdex-accelerator.vercel.app/c/jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Display hashtags on resource items with links.
  * Optional announcement banner in the header.
  * Optional announcement post-it in the left sidebar.

* Style
  * Unified title styling via new item-title class across feeds and portfolio cards.
  * Adjusted underline offsets, removed fixed line-heights, and enlarged external-link indicator.
  * Reduced spacing between left sidebar nav items and tweaked right sidebar CTA underline.
  * Secondary navbar now uses a full-height container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->