### PR TITLE
chore(ui): view adjusted paddings of page title

### DIFF
--- a/src/lib/components/PageTitle/index.svelte
+++ b/src/lib/components/PageTitle/index.svelte
@@ -8,6 +8,9 @@
   let isMultiLine = false;
   let isChecked = false;
 
+  const defaultClasses =
+    'text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s';
+
   onMount(async () => {
     await tick();
     checkSingleLine();
@@ -22,7 +25,7 @@
       tempElement.style.whiteSpace = 'nowrap';
       tempElement.style.width = 'auto';
 
-      tempElement.className = className.replace(/!?pt-[\d.]+/g, '').trim();
+      tempElement.className = `${defaultClasses} ${className}`.replace(/!?pt-[\d.]+/g, '').trim();
 
       document.body.appendChild(tempElement);
       const singleLineHeight = tempElement.offsetHeight;
@@ -38,8 +41,8 @@
   }
 
   $: finalClassName = isChecked
-    ? `${className} ${isMultiLine ? '' : '!pt-0'}`.trim()
-    : `${className} !pt-0`.trim();
+    ? `${defaultClasses} ${className} ${isMultiLine ? '' : '!pt-0'}`.trim()
+    : `${defaultClasses} ${className} !pt-0`.trim();
 </script>
 
 <h1 class={finalClassName} {id} bind:this={headingElement}>

--- a/src/lib/components/PageTitle/index.svelte
+++ b/src/lib/components/PageTitle/index.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+
+  export let className: string = '';
+  export let id: string = '';
+
+  let headingElement: HTMLElement | undefined;
+  let isMultiLine = false;
+  let isChecked = false;
+
+  onMount(async () => {
+    await tick();
+    checkSingleLine();
+  });
+
+  function checkSingleLine() {
+    if (headingElement) {
+      const tempElement = document.createElement('h1');
+      tempElement.innerHTML = headingElement.innerHTML;
+      tempElement.style.position = 'absolute';
+      tempElement.style.visibility = 'hidden';
+      tempElement.style.whiteSpace = 'nowrap';
+      tempElement.style.width = 'auto';
+
+      tempElement.className = className.replace(/!?pt-[\d.]+/g, '').trim();
+
+      document.body.appendChild(tempElement);
+      const singleLineHeight = tempElement.offsetHeight;
+
+      document.body.removeChild(tempElement);
+
+      const actualHeight = headingElement.offsetHeight;
+
+      const tolerance = 5;
+      isMultiLine = actualHeight > singleLineHeight + tolerance;
+      isChecked = true;
+    }
+  }
+
+  $: finalClassName = isChecked
+    ? `${className} ${isMultiLine ? '' : '!pt-0'}`.trim()
+    : `${className} !pt-0`.trim();
+</script>
+
+<h1 class={finalClassName} {id} bind:this={headingElement}>
+  <slot />
+</h1>

--- a/src/lib/components/PageTitle/index.svelte
+++ b/src/lib/components/PageTitle/index.svelte
@@ -41,8 +41,8 @@
   }
 
   $: finalClassName = isChecked
-    ? `${defaultClasses} ${className} ${isMultiLine ? '' : '!pt-0'}`.trim()
-    : `${defaultClasses} ${className} !pt-0`.trim();
+    ? `${defaultClasses} ${className} ${isMultiLine ? '' : '!pb-0'}`.trim()
+    : `${defaultClasses} ${className} !pb-0`.trim();
 </script>
 
 <h1 class={finalClassName} {id} bind:this={headingElement}>

--- a/src/lib/config/announcement.json
+++ b/src/lib/config/announcement.json
@@ -1,12 +1,12 @@
 {
   "banner": {
     "show": true,
-    "href": "/schedule-meeting",
+    "href": "/c/announcements/holdex-is-heading-to-consensus-in-hong-kong-meet-us-there",
     "text": "📣 Join us at Token2049 Singapore, 29 Sep - 5 Oct 2025!"
   },
   "post_it": {
     "show": true,
-    "href": "/schedule-meeting",
+    "href": "/c/announcements/holdex-is-heading-to-consensus-in-hong-kong-meet-us-there",
     "date": "29 Sep - 5 Oct 2025",
     "location": "Singapore",
     "content": "Meet us at Token2049!"

--- a/src/routes/(pages)/+page.svelte
+++ b/src/routes/(pages)/+page.svelte
@@ -9,6 +9,7 @@
   import { routes } from '$lib/config';
   import type { PageData } from './$types';
   import Link from '$components/BodyRenderer/Blocks/link.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
 
   export let data: PageData;
 
@@ -27,7 +28,6 @@
   $: gradientStyle = sanitizeStyle(
     'background-image: linear-gradient(165deg, #393F4F 20%, #10141F 40%); padding: 0.0625rem;'
   );
-  
 </script>
 
 <MetaTags

--- a/src/routes/(pages)/about/+page.svelte
+++ b/src/routes/(pages)/about/+page.svelte
@@ -3,6 +3,7 @@
   import MetaTags from '$components/MetaTags/index.svelte';
   import Parser, { type Message } from '$components/BodyParser';
   import BodyRenderer from '$components/BodyRenderer/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
   import { routes } from '$lib/config';
   import type { PageData } from './$types';
 

--- a/src/routes/(pages)/about/template.pug
+++ b/src/routes/(pages)/about/template.pug
@@ -6,6 +6,9 @@ include ../c/mixins
       +crumbItemLink("/", "Holdex")
       +crumbDelimiter
       +crumbItemText("About")
-    h1.text-title-l.font-satoshi.text-center(class="py-3.625 smDown:py-0 smDown:text-left xs:text-title-s" id="{message.id}") About Holdex
+    PageTitle(
+      className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
+      id="{message.id}"
+    ) About Holdex
   +content-wrapper
     BodyRenderer(blocks="{message.blocks}")

--- a/src/routes/(pages)/about/template.pug
+++ b/src/routes/(pages)/about/template.pug
@@ -6,9 +6,6 @@ include ../c/mixins
       +crumbItemLink("/", "Holdex")
       +crumbDelimiter
       +crumbItemText("About")
-    PageTitle(
-      className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
-      id="{message.id}"
-    ) About Holdex
+    PageTitle(id="{message.id}") About Holdex
   +content-wrapper
     BodyRenderer(blocks="{message.blocks}")

--- a/src/routes/(pages)/apply/+page.svelte
+++ b/src/routes/(pages)/apply/+page.svelte
@@ -5,6 +5,7 @@
   import { routes } from '$lib/config';
   import MetaTags from '$components/MetaTags/index.svelte';
   import Icon from '$components/Icons/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
 </script>
 
 <template lang="pug" src="./template.pug">

--- a/src/routes/(pages)/c/+page.svelte
+++ b/src/routes/(pages)/c/+page.svelte
@@ -16,6 +16,7 @@
   } from '$components/Icons';
   import MetaTags from '$components/MetaTags/index.svelte';
   import Icon from '$components/Icons/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
 
   import DefaultFeedItem from '$components/Feed/Item/index.svelte';
   import Feed from '$components/Feed/index.svelte';

--- a/src/routes/(pages)/c/[slug]/+page.svelte
+++ b/src/routes/(pages)/c/[slug]/+page.svelte
@@ -16,6 +16,7 @@
   import MetaTags from '$components/MetaTags/index.svelte';
   import Hashtag from '$components/Hashtag/index.svelte';
   import Icon from '$components/Icons/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
 
   import DefaultFeedItem from '$components/Feed/Item/index.svelte';
   import Feed from '$components/Feed/index.svelte';

--- a/src/routes/(pages)/c/[slug]/[messageSlug]/+page.svelte
+++ b/src/routes/(pages)/c/[slug]/[messageSlug]/+page.svelte
@@ -7,6 +7,7 @@
   import BodyRenderer from '$components/BodyRenderer/index.svelte';
   import Icon from '$components/Icons/index.svelte';
   import MetaTags from '$components/MetaTags/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
   import TextParagraph from '$components/TextParagraph/index.svelte';
   import Button from '$components/Button/index.svelte';
 

--- a/src/routes/(pages)/c/guides/+page.svelte
+++ b/src/routes/(pages)/c/guides/+page.svelte
@@ -16,6 +16,7 @@
   } from '$components/Icons';
   import MetaTags from '$components/MetaTags/index.svelte';
   import Icon from '$components/Icons/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
 
   import DefaultFeedItem from '$components/Feed/Item/index.svelte';
   import Feed from '$components/Feed/index.svelte';

--- a/src/routes/(pages)/c/mixins.pug
+++ b/src/routes/(pages)/c/mixins.pug
@@ -73,7 +73,9 @@ mixin button-icon-small(icon)
       Icon(icon=icon width="{17}" height="{17}" colorInherit)
 
 mixin messageHeader(title, subtitle, cover = null)
-  h1(class="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s")&attributes(attributes)= title
+  PageTitle(
+    className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
+  )&attributes(attributes)= title
   if cover && cover !== ""
     img(
       src=cover

--- a/src/routes/(pages)/c/mixins.pug
+++ b/src/routes/(pages)/c/mixins.pug
@@ -73,9 +73,7 @@ mixin button-icon-small(icon)
       Icon(icon=icon width="{17}" height="{17}" colorInherit)
 
 mixin messageHeader(title, subtitle, cover = null)
-  PageTitle(
-    className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
-  )&attributes(attributes)= title
+  PageTitle&attributes(attributes)= title
   if cover && cover !== ""
     img(
       src=cover

--- a/src/routes/(pages)/for-startups/+page.svelte
+++ b/src/routes/(pages)/for-startups/+page.svelte
@@ -3,6 +3,7 @@
   import MetaTags from '$components/MetaTags/index.svelte';
   import Parser, { type Message } from '$components/BodyParser';
   import BodyRenderer from '$components/BodyRenderer/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
   import { routes } from '$lib/config';
   import type { PageData } from './$types';
 

--- a/src/routes/(pages)/for-startups/template.pug
+++ b/src/routes/(pages)/for-startups/template.pug
@@ -6,9 +6,6 @@ include ../c/mixins
       +crumbItemLink("/", "Holdex")
       +crumbDelimiter
       +crumbItemText("For Startups")
-    PageTitle(
-      className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
-      id="{message.id}"
-    ) {message.title}
+    PageTitle(id="{message.id}") {message.title}
   +content-wrapper
     BodyRenderer(blocks="{message.blocks}")

--- a/src/routes/(pages)/for-startups/template.pug
+++ b/src/routes/(pages)/for-startups/template.pug
@@ -6,6 +6,9 @@ include ../c/mixins
       +crumbItemLink("/", "Holdex")
       +crumbDelimiter
       +crumbItemText("For Startups")
-    h1.text-title-l.font-satoshi.text-center(class="py-3.625 smDown:py-0 smDown:text-left xs:text-title-s" id="{message.id}") {message.title}
+    PageTitle(
+      className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
+      id="{message.id}"
+    ) {message.title}
   +content-wrapper
     BodyRenderer(blocks="{message.blocks}")

--- a/src/routes/(pages)/portfolio/+page.svelte
+++ b/src/routes/(pages)/portfolio/+page.svelte
@@ -16,6 +16,7 @@
   } from '$components/Icons';
   import MetaTags from '$components/MetaTags/index.svelte';
   import Icon from '$components/Icons/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
 
   // import DefaultFeedItem from '$components/Feed/Item/index.svelte';
   // import Feed from '$components/Feed/index.svelte';

--- a/src/routes/(pages)/schedule-meeting/+page.svelte
+++ b/src/routes/(pages)/schedule-meeting/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MetaTags from '$components/MetaTags/index.svelte';
+  import PageTitle from '$components/PageTitle/index.svelte';
   import { routes } from '$lib/config';
   import { onMount } from 'svelte';
 
@@ -41,17 +42,17 @@
     Cal.ns['30min']('inline', {
       elementOrSelector: '#my-cal-inline-30min',
       config: { layout: 'month_view' },
-      calLink: 'zolotokrylin/30min'
+      calLink: 'zolotokrylin/30min',
     });
 
     Cal.ns['30min']('ui', {
       theme: 'dark',
       cssVarsPerTheme: {
         light: { 'cal-brand': '#11141E' },
-        dark: { 'cal-brand': '#ffffff' }
+        dark: { 'cal-brand': '#ffffff' },
       },
       hideEventTypeDetails: false,
-      layout: 'month_view'
+      layout: 'month_view',
     });
   });
 </script>
@@ -61,6 +62,5 @@
   description="Schedule a meeting with us to discuss your startup's needs"
   path={routes.scheduleMeeting}
 />
-
 
 <template lang="pug" src="./template.pug"></template>

--- a/src/routes/(pages)/schedule-meeting/template.pug
+++ b/src/routes/(pages)/schedule-meeting/template.pug
@@ -6,7 +6,5 @@ include ../c/mixins
       +crumbItemLink("/", "Holdex")
       +crumbDelimiter
       +crumbItemText("Schedule Meeting")
-    PageTitle(
-      className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
-    ) Schedule Meeting
+    PageTitle Schedule Meeting
     .w-full(id="my-cal-inline-30min")

--- a/src/routes/(pages)/schedule-meeting/template.pug
+++ b/src/routes/(pages)/schedule-meeting/template.pug
@@ -6,5 +6,7 @@ include ../c/mixins
       +crumbItemLink("/", "Holdex")
       +crumbDelimiter
       +crumbItemText("Schedule Meeting")
-    h1.text-title-l.font-satoshi.text-center(class="py-3.625 smDown:py-0 smDown:text-left xs:text-title-s") Schedule Meeting
+    PageTitle(
+      className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
+    ) Schedule Meeting
     .w-full(id="my-cal-inline-30min")

--- a/src/routes/(pages)/template.pug
+++ b/src/routes/(pages)/template.pug
@@ -6,10 +6,7 @@ include ./common-mixins
   +section-hero-wrapper
     +nav-crumbs
       +crumbItemLink("/", "Holdex")
-    PageTitle(
-        className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 xs:text-left xs:text-title-s"
-        id="{message.id}"
-      )
+    PageTitle(id="{message.id}")
       | At&nbsp;
       span.underline.font-satoshi Holdex
       | , we help innovators build the next Web3 products
@@ -25,11 +22,15 @@ include ./common-mixins
     p.text-t1 { @html signature }
 
   +section-learn-wrapper
-    h2.text-title-l.font-satoshi.text-center(class="py-3.625 smDown:py-0 smDown:text-left xs:text-title-s")
+    h2.text-title-l.font-satoshi.text-center(
+      class="py-3.625 smDown:py-0 smDown:text-left xs:text-title-s"
+    )
       | Learn
     p.text-subtitle-l.font-inter.text-center.text-t2(class="w-full smDown:text-left max-w-[612px]")
       | Pioneering the Launch of Sustainable Applications That Drive Long-Term Financial Freedom
-    .cards-wrapper(class="w-full grid grid-cols-2 smDown:grid-cols-1 gap-8 smDown:gap-6.5 auto-rows-max my-3.625 smDown:my-0")
+    .cards-wrapper(
+      class="w-full grid grid-cols-2 smDown:grid-cols-1 gap-8 smDown:gap-6.5 auto-rows-max my-3.625 smDown:my-0"
+    )
       +guideCard("/c/learn/article-top-web3-security-auditors", "Best Web3 Security Auditors", "Discover the top auditors ensuring the safety and integrity of blockchain and decentralized applications.", "bg-card-1-light dark:bg-card-1-dark")
       +guideCard("/c?filter=defi", "Defi Guides", "Explore the exciting world of decentralized finance with our guides and information to empower your journey", "bg-card-2-light dark:bg-card-2-dark")
     +cta("Looking for ", "Learn more", "", "/c/guides")

--- a/src/routes/(pages)/template.pug
+++ b/src/routes/(pages)/template.pug
@@ -6,7 +6,10 @@ include ./common-mixins
   +section-hero-wrapper
     +nav-crumbs
       +crumbItemLink("/", "Holdex")
-    h1.text-title-l.font-satoshi.text-center(class="py-3.625 smDown:py-0 xs:text-left xs:text-title-s" id="{message.id}")
+    PageTitle(
+        className="text-title-l font-satoshi text-center py-3.625 smDown:py-0 xs:text-left xs:text-title-s"
+        id="{message.id}"
+      )
       | At&nbsp;
       span.underline.font-satoshi Holdex
       | , we help innovators build the next Web3 products


### PR DESCRIPTION
resolves https://github.com/holdex/marketing/issues/314
resolves https://github.com/holdex/marketing/issues/295

https://holdex-venture-studio-git-heading-che-b8ccd4-holdex-accelerator.vercel.app/
https://holdex-venture-studio-git-heading-che-b8ccd4-holdex-accelerator.vercel.app/about

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a PageTitle component that auto-adjusts spacing for single- vs multi-line titles.
- Refactor
  - Replaced legacy h1 headers with PageTitle across multiple pages and unified header structure; added structured header wrappers and breadcrumbs on select pages.
- Chores
  - Updated announcement links to point to the new event destination.
- Style
  - Minor formatting and whitespace cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->